### PR TITLE
Fix circular import by relocating submit handler

### DIFF
--- a/Project-Root/output.js
+++ b/Project-Root/output.js
@@ -5,7 +5,7 @@
 // và gắn các sự kiện để người dùng có thể tương tác.
 
 import { jarsConfig, state } from './data.js';
-import { handleTransactionSubmit, loadStateFromLocalStorage } from './process.js';
+import { saveStateToLocalStorage, loadStateFromLocalStorage } from './process.js';
 
 // Biến toàn cục DOM
 const totalBalanceEl = document.getElementById('total-balance');
@@ -73,6 +73,43 @@ export function showModal(modalId) {
 
 export function hideModal(modalId) {
     document.getElementById(modalId).classList.replace('flex', 'hidden');
+}
+
+function handleTransactionSubmit(e) {
+    e.preventDefault();
+
+    const type = document.getElementById('transaction-type').value;
+    const amount = parseFloat(document.getElementById('transaction-amount').value);
+    const description = document.getElementById('transaction-description').value;
+    const jarId = document.getElementById('transaction-jar').value;
+
+    if (isNaN(amount) || amount <= 0 || !description || !jarId) {
+        console.error('Dữ liệu giao dịch không hợp lệ');
+        return;
+    }
+
+    const currentBalance = state.jars[jarId]?.balance || 0;
+    if (type === 'expense' && currentBalance < amount) {
+        console.error(`Số dư trong hũ "${jarsConfig[jarId].name}" không đủ.`);
+        return;
+    }
+
+    state.jars[jarId].balance += (type === 'income' ? amount : -amount);
+
+    const newTransaction = {
+        id: Date.now().toString(),
+        type,
+        amount,
+        description,
+        jarId,
+        createdAt: new Date().toISOString(),
+    };
+    state.transactions.unshift(newTransaction);
+
+    saveStateToLocalStorage();
+    renderOutput();
+    hideModal('transaction-modal');
+    document.getElementById('transaction-form').reset();
 }
 
 function formatCurrency(amount) {

--- a/Project-Root/process.js
+++ b/Project-Root/process.js
@@ -7,45 +7,8 @@
 
 // Nhập dữ liệu cấu hình và state
 import { jarsConfig, state, updateState } from './data.js';
-import { renderOutput, hideModal } from './output.js';
 
 // Export các hàm để các module khác có thể dùng
-export function handleTransactionSubmit(e) {
-    e.preventDefault();
-
-    const type = document.getElementById('transaction-type').value;
-    const amount = parseFloat(document.getElementById('transaction-amount').value);
-    const description = document.getElementById('transaction-description').value;
-    const jarId = document.getElementById('transaction-jar').value;
-
-    if (isNaN(amount) || amount <= 0 || !description || !jarId) {
-        console.error("Dữ liệu giao dịch không hợp lệ");
-        return;
-    }
-
-    const currentBalance = state.jars[jarId]?.balance || 0;
-    if (type === 'expense' && currentBalance < amount) {
-        console.error(`Số dư trong hũ "${jarsConfig[jarId].name}" không đủ.`);
-        return;
-    }
-
-    state.jars[jarId].balance += (type === 'income' ? amount : -amount);
-
-    const newTransaction = {
-        id: Date.now().toString(),
-        type,
-        amount,
-        description,
-        jarId,
-        createdAt: new Date().toISOString()
-    };
-    state.transactions.unshift(newTransaction);
-
-    saveStateToLocalStorage();
-    renderOutput();
-    hideModal('transaction-modal');
-    document.getElementById('transaction-form').reset();
-}
 
 export function calculateTotalBalance() {
     state.totalBalance = Object.values(state.jars).reduce((sum, jar) => sum + (jar.balance || 0), 0);

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Dự án ứng dụng web giúp người dùng quản lý tài chính cá nhân 
 | `main.js`    | File trung tâm, import toàn bộ các module `input`, `process`, `output` |
 | `data.js`    | Dữ liệu cấu hình (5 hũ), biến `state`, và hàm cập nhật `state`         |
 | `input.js`   | Gán các biến DOM (`getElementById`) và chuẩn bị dữ liệu đầu vào        |
-| `process.js` | Chứa các hàm xử lý logic như `handleTransactionSubmit`, `saveState`... |
-| `output.js`  | Vẽ lại giao diện, hiển thị biểu đồ, xử lý sự kiện click, submit,...    |
+| `process.js` | Chứa các hàm xử lý logic, lưu/đọc LocalStorage... |
+| `output.js`  | Vẽ giao diện, xử lý sự kiện (như `handleTransactionSubmit`), biểu đồ... |
 
 ---
 


### PR DESCRIPTION
## Summary
- move `handleTransactionSubmit` from `process.js` to `output.js`
- adjust imports accordingly
- document new file responsibilities in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6884e0be62548327b64b71568f9e3ffb